### PR TITLE
Implement Extension registration API

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,6 @@
 // under the License.
 //! [`CliApp`]: Command Line User Interface
 
-use crate::app::state;
 use crate::execution::ExecutionContext;
 use color_eyre::eyre::eyre;
 use datafusion::arrow::util::pretty::pretty_format_batches;
@@ -35,9 +34,7 @@ pub struct CliApp {
 }
 
 impl CliApp {
-    pub fn new(state: state::AppState<'static>) -> Self {
-        let execution = ExecutionContext::new(state.config.execution.clone());
-
+    pub fn new(execution: ExecutionContext) -> Self {
         Self { execution }
     }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -33,7 +33,7 @@ use {
 };
 
 use crate::config::ExecutionConfig;
-use crate::extensions::{all_extensions, DftSessionStateBuilder};
+use crate::extensions::{enabled_extensions, DftSessionStateBuilder};
 
 /// Structure for executing queries either locally or remotely (via FlightSQL)
 ///
@@ -58,7 +58,7 @@ impl ExecutionContext {
     /// Construct a new `ExecutionContext` with the specified configuration
     pub fn try_new(config: &ExecutionConfig) -> Result<Self> {
         let mut builder = DftSessionStateBuilder::new();
-        for extension in all_extensions() {
+        for extension in enabled_extensions() {
             builder = extension.register(config, builder)?;
         }
 

--- a/src/extensions/builder.rs
+++ b/src/extensions/builder.rs
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`DftSessionStateBuilder`] for configuring DataFusion [`SessionState`]
+
+use datafusion::catalog::TableProviderFactory;
+use datafusion::execution::context::SessionState;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::prelude::SessionConfig;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// Builds a DataFusion [`SessionState`] with any necessary configuration
+///
+/// Ideally we would use the DataFusion [`SessionStateBuilder`], but it doesn't
+/// currently have all the needed APIs. Once we have a good handle on the needed
+/// APIs we can upstream them to DataFusion.
+///
+/// List of things that would be nice to add upstream:
+/// TODO: Implement Debug for SessionStateBuilder upstream
+/// TODO: Implement with_table_factory to add a single TableProviderFactory to the list of factories
+/// TODO: Implement some way to get access to the current RuntimeEnv (to register object stores)
+/// TODO: Implement a way to add just a single TableProviderFactory
+/// TODO: Make TableFactoryProvider implement Debug
+/// TODO: rename RuntimeEnv::new() to RuntimeEnv::try_new() as it returns a Result
+//#[derive(Debug)]
+pub struct DftSessionStateBuilder {
+    session_config: SessionConfig,
+    table_factories: Option<HashMap<String, Arc<dyn TableProviderFactory>>>,
+    runtime_env: Option<Arc<RuntimeEnv>>,
+}
+
+impl Debug for DftSessionStateBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DftSessionStateBuilder")
+            .field("session_config", &self.session_config)
+            //.field("table_factories", &self.table_factories)
+            .field(
+                "table_factories",
+                &"TODO TableFactoryDoes not implement Debug",
+            )
+            .field("runtime_env", &self.runtime_env)
+            .finish()
+    }
+}
+
+impl Default for DftSessionStateBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DftSessionStateBuilder {
+    /// Create a new builder
+    pub fn new() -> Self {
+        let session_config = SessionConfig::default()
+            // TODO why is batch size 1?
+            .with_batch_size(1)
+            .with_information_schema(true);
+
+        Self {
+            session_config,
+            table_factories: None,
+            runtime_env: None,
+        }
+    }
+
+    /// Add a table factory to the list of factories on this builder
+    pub fn with_table_factory(
+        mut self,
+        name: &str,
+        factory: Arc<dyn TableProviderFactory>,
+    ) -> Self {
+        if self.table_factories.is_none() {
+            self.table_factories = Some(HashMap::from([(name.to_string(), factory)]));
+        } else {
+            self.table_factories
+                .as_mut()
+                .unwrap()
+                .insert(name.to_string(), factory);
+        }
+        self
+    }
+
+    /// Return the current [`RuntimeEnv`], creating a default if it doesn't exist
+    pub fn runtime_env(&mut self) -> &RuntimeEnv {
+        if self.runtime_env.is_none() {
+            self.runtime_env = Some(Arc::new(RuntimeEnv::default()));
+        }
+        self.runtime_env.as_ref().unwrap()
+    }
+
+    /// Build the [`SessionState`] from the specified configuration
+    pub fn build(self) -> datafusion_common::Result<SessionState> {
+        let Self {
+            session_config,
+            table_factories,
+            runtime_env,
+        } = self;
+
+        let mut builder = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config);
+
+        if let Some(runtime_env) = runtime_env {
+            builder = builder.with_runtime_env(runtime_env);
+        }
+        if let Some(table_factories) = table_factories {
+            builder = builder.with_table_factories(table_factories);
+        }
+
+        Ok(builder.build())
+    }
+}

--- a/src/extensions/deltalake.rs
+++ b/src/extensions/deltalake.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! DeltaLake integration: [DeltaLakeExtension]
+
+use crate::config::ExecutionConfig;
+use crate::extensions::{DftSessionStateBuilder, Extension};
+use deltalake::delta_datafusion::DeltaTableFactory;
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct DeltaLakeExtension {}
+
+impl DeltaLakeExtension {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Extension for DeltaLakeExtension {
+    fn register(
+        &self,
+        _config: &ExecutionConfig,
+        builder: DftSessionStateBuilder,
+    ) -> datafusion_common::Result<DftSessionStateBuilder> {
+        Ok(builder.with_table_factory("DELTATABLE", Arc::new(DeltaTableFactory {})))
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module has code to register DataFusion extensions
+
+use crate::config::ExecutionConfig;
+use datafusion::common::Result;
+use std::fmt::Debug;
+
+mod builder;
+#[cfg(feature = "deltalake")]
+mod deltalake;
+#[cfg(feature = "s3")]
+mod s3;
+
+pub use builder::DftSessionStateBuilder;
+
+pub trait Extension: Debug {
+    /// Registers this extension with the DataFusion [`SessionStateBuilder`]
+    fn register(
+        &self,
+        _config: &ExecutionConfig,
+        _builder: DftSessionStateBuilder,
+    ) -> Result<DftSessionStateBuilder>;
+}
+
+/// Return all extensions currently enabled
+pub fn all_extensions() -> Vec<Box<dyn Extension>> {
+    vec![
+        #[cfg(feature = "s3")]
+        Box::new(s3::AwsS3Extension::new()),
+        #[cfg(feature = "deltalake")]
+        Box::new(deltalake::DeltaLakeExtension::new()),
+    ]
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -39,7 +39,7 @@ pub trait Extension: Debug {
 }
 
 /// Return all extensions currently enabled
-pub fn all_extensions() -> Vec<Box<dyn Extension>> {
+pub fn enabled_extensions() -> Vec<Box<dyn Extension>> {
     vec![
         #[cfg(feature = "s3")]
         Box::new(s3::AwsS3Extension::new()),

--- a/src/extensions/s3.rs
+++ b/src/extensions/s3.rs
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! AWS S3 Integration: [AwsS3Extension]
+
+use crate::config::ExecutionConfig;
+use crate::extensions::{DftSessionStateBuilder, Extension};
+use log::info;
+use std::sync::Arc;
+
+use url::Url;
+
+#[derive(Debug, Default)]
+pub struct AwsS3Extension {}
+
+impl AwsS3Extension {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Extension for AwsS3Extension {
+    fn register(
+        &self,
+        config: &ExecutionConfig,
+        mut builder: DftSessionStateBuilder,
+    ) -> datafusion_common::Result<DftSessionStateBuilder> {
+        let Some(object_store_config) = &config.object_store else {
+            return Ok(builder);
+        };
+
+        let Some(s3_configs) = &object_store_config.s3 else {
+            return Ok(builder);
+        };
+
+        info!("S3 configs exists");
+        for s3_config in s3_configs {
+            match s3_config.to_object_store() {
+                Ok(object_store) => {
+                    info!("Created object store");
+                    if let Some(object_store_url) = s3_config.object_store_url() {
+                        info!("Endpoint exists");
+                        if let Ok(parsed_endpoint) = Url::parse(object_store_url) {
+                            info!("Parsed endpoint");
+                            builder
+                                .runtime_env()
+                                .register_object_store(&parsed_endpoint, Arc::new(object_store));
+                            info!("Registered s3 object store");
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error creating object store: {:?}", e);
+                }
+            }
+        }
+
+        Ok(builder)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod args;
 pub mod cli;
 pub mod config;
 pub mod execution;
+pub mod extensions;
 pub mod telemetry;

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -19,70 +19,103 @@
 
 use dft::app::state::initialize;
 use dft::app::{App, AppEvent};
+use dft::execution::ExecutionContext;
 use ratatui::crossterm::event;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 #[tokio::test]
-async fn run_app_with_no_args() {
-    let config_path = tempdir().unwrap();
-    let state = initialize(config_path.path().to_path_buf());
-    let _app = App::new(state);
+async fn construct_with_no_args() {
+    let _test_app = TestApp::new();
 }
 
 #[tokio::test]
-async fn quit_app_from_all_tabs() {
-    let config_path = tempdir().unwrap();
-    let state = initialize(config_path.path().to_path_buf());
-
+async fn quit_app_from_sql_tab() {
+    let mut test_app = TestApp::new();
     // SQL Tab
-    let mut app = App::new(state);
     let key = event::KeyEvent::new(event::KeyCode::Char('q'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(key);
-    app.handle_app_event(app_event).unwrap();
+    test_app.handle_app_event(app_event).unwrap();
     // Ideally, we figure out a way to check that the app actually quits
-    assert!(app.state().should_quit);
+    assert!(test_app.state().should_quit);
+}
 
-    // FlightSQL Tab
-    let state = initialize(config_path.path().to_path_buf());
-    let mut app = App::new(state);
+#[tokio::test]
+async fn quit_app_from_flightsql_tab() {
+    let mut test_app = TestApp::new();
     let flightsql_key = event::KeyEvent::new(event::KeyCode::Char('2'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(flightsql_key);
-    app.handle_app_event(app_event).unwrap();
+    test_app.handle_app_event(app_event).unwrap();
     let key = event::KeyEvent::new(event::KeyCode::Char('q'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(key);
-    app.handle_app_event(app_event).unwrap();
-    assert!(app.state().should_quit);
+    test_app.handle_app_event(app_event).unwrap();
+    assert!(test_app.state().should_quit);
+}
 
-    // History Tab
-    let state = initialize(config_path.path().to_path_buf());
-    let mut app = App::new(state);
+#[tokio::test]
+async fn quit_app_from_history_tab() {
+    let mut test_app = TestApp::new();
     let history_key = event::KeyEvent::new(event::KeyCode::Char('3'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(history_key);
-    app.handle_app_event(app_event).unwrap();
+    test_app.handle_app_event(app_event).unwrap();
     let key = event::KeyEvent::new(event::KeyCode::Char('q'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(key);
-    app.handle_app_event(app_event).unwrap();
-    assert!(app.state().should_quit);
+    test_app.handle_app_event(app_event).unwrap();
+    assert!(test_app.state().should_quit);
+}
 
-    // Logs Tab
-    let state = initialize(config_path.path().to_path_buf());
-    let mut app = App::new(state);
+#[tokio::test]
+async fn quit_app_from_logs_tab() {
+    let mut test_app = TestApp::new();
     let logs_key = event::KeyEvent::new(event::KeyCode::Char('4'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(logs_key);
-    app.handle_app_event(app_event).unwrap();
+    test_app.handle_app_event(app_event).unwrap();
     let key = event::KeyEvent::new(event::KeyCode::Char('q'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(key);
-    app.handle_app_event(app_event).unwrap();
-    assert!(app.state().should_quit);
+    test_app.handle_app_event(app_event).unwrap();
+    assert!(test_app.state().should_quit);
+}
 
-    // Context Tab
-    let state = initialize(config_path.path().to_path_buf());
-    let mut app = App::new(state);
+#[tokio::test]
+async fn quit_app_from_context_tab() {
+    let mut test_app = TestApp::new();
     let context_key = event::KeyEvent::new(event::KeyCode::Char('5'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(context_key);
-    app.handle_app_event(app_event).unwrap();
+    test_app.handle_app_event(app_event).unwrap();
     let key = event::KeyEvent::new(event::KeyCode::Char('q'), event::KeyModifiers::NONE);
     let app_event = AppEvent::Key(key);
-    app.handle_app_event(app_event).unwrap();
-    assert!(app.state().should_quit);
+    test_app.handle_app_event(app_event).unwrap();
+    assert!(test_app.state().should_quit);
+}
+
+/// Fixture with an [`App`] instance and other temporary state
+struct TestApp<'app> {
+    /// Temporary directory for configuration files
+    ///
+    /// The directory is removed when the object is dropped so this
+    /// field must remain alive while the app is running
+    #[allow(dead_code)]
+    config_path: TempDir,
+    /// The [`App`] instance
+    app: App<'app>,
+}
+
+impl<'app> TestApp<'app> {
+    /// Create a new [`TestApp`] instance configured with a temporary directory
+    fn new() -> Self {
+        let config_path = tempdir().unwrap();
+        let state = initialize(config_path.path().to_path_buf());
+        let execution = ExecutionContext::try_new(&state.config.execution).unwrap();
+        let app = App::new(state, execution);
+        Self { config_path, app }
+    }
+
+    /// Call app.event_handler with the given event
+    pub fn handle_app_event(&mut self, event: AppEvent) -> color_eyre::Result<()> {
+        self.app.handle_app_event(event)
+    }
+
+    /// Return the app state
+    pub fn state(&self) -> &dft::app::state::AppState {
+        self.app.state()
+    }
 }


### PR DESCRIPTION
Last part of https://github.com/datafusion-contrib/datafusion-dft/issues/132
Closes https://github.com/datafusion-contrib/datafusion-dft/issues/132

# Rationale
I want to begin working on integration other components (e.g. https://github.com/datafusion-contrib/datafusion-dft/issues/130) and I want to avoid littering the code with `cfg` flags.

I think after this PR we'll have two `cfg` uses for each extension. Short of macros this is the best I can come up with

Changes:
1. Pull deltalake and s3 registration into their own module
2. Create a new API for registering extensions
3. Create a list of nice to have APIs upstream in DataFusion

