### PR TITLE
Make DDL path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Some of the current and planned features are:
   - Deltalake
   - Iceberg (TODO)
   - Hudi (TODO)
-- Preloading DDL from `~/.datafusion/.datafusionrc` for local database available on startup
+- Preloading DDL from `~/.config/dft/ddl.sql` (or a user defined path) for local database available on startup
 - "Catalog File" support - see [#122](https://github.com/datafusion-contrib/datafusion-tui/issues/122)
   - Save table definitions *and* data
   - Save parquet metadata from remote object stores
@@ -262,7 +262,7 @@ The `dft` configuration is stored in `~/.config/dft/config.toml`.  All configura
 
 #### Execution Config
 
-The execution config is where you can define the `ObjectStore`s that you want to use in your queries.  For example, if you have an S3 bucket you want to query you could define it like so:
+The execution config is where you can define query execution properties.  You can configure the `ObjectStore`s that you want to use in your queries and path of a DDL file that you want to run on startup.  For example, if you have an S3 bucket you want to query you could define it like so:
 
 ```toml
 [[execution.object_store.s3]]
@@ -273,6 +273,13 @@ aws_access_key_id = "MY_ACCESS_KEY"
 aws_secret = "MY SECRET"
 aws_session_token = "MY_SESSION"
 aws_allow_http = false
+```
+
+And define a custom DDL path like so (the default is `~/.config/dft/ddl.sql`).
+
+```toml
+[execution]
+ddl_path = "/path/to/my/ddl.sql"
 ```
 
 Multiple `ObjectStore`s can be defined in the config file. In the future datafusion `SessionContext` and `SessionState` options can be configured here.

--- a/src/app/app_execution.rs
+++ b/src/app/app_execution.rs
@@ -305,4 +305,12 @@ impl AppExecution {
     pub fn flightsql_client(&self) -> &Mutex<Option<FlightSqlServiceClient<Channel>>> {
         self.inner.flightsql_client()
     }
+
+    pub fn load_ddl(&self) -> Option<String> {
+        self.inner.load_ddl()
+    }
+
+    pub fn save_ddl(&self, ddl: String) {
+        self.inner.save_ddl(ddl)
+    }
 }

--- a/src/app/handlers/sql.rs
+++ b/src/app/handlers/sql.rs
@@ -21,10 +21,7 @@ use log::{error, info};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::App;
-use crate::{
-    app::{handlers::tab_navigation_handler, state::tabs::sql::SQLTabMode, AppEvent},
-    config::{load_ddl, save_ddl},
-};
+use crate::app::{handlers::tab_navigation_handler, state::tabs::sql::SQLTabMode, AppEvent};
 
 pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
     match key.code {
@@ -51,7 +48,7 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
             if *app.state.sql_tab.mode() == SQLTabMode::DDL {
                 let textarea = app.state.sql_tab.active_editor_cloned();
                 let ddl = textarea.lines().join("\n");
-                save_ddl(ddl)
+                app.execution.save_ddl(ddl)
             }
         }
         KeyCode::Down => {
@@ -81,7 +78,7 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
             }
             SQLTabMode::DDL => {
                 let _event_tx = app.event_tx().clone();
-                let ddl = load_ddl().unwrap_or_default();
+                let ddl = app.execution.load_ddl().unwrap_or_default();
                 if let Err(e) = _event_tx.send(AppEvent::ExecuteDDL(ddl)) {
                     error!("Error sending ExecuteDDL event: {:?}", e);
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -42,7 +42,6 @@ use tokio_util::sync::CancellationToken;
 
 use self::app_execution::AppExecution;
 use self::handlers::{app_event_handler, crossterm_event_handler};
-use crate::config::load_ddl;
 use crate::execution::ExecutionContext;
 
 #[derive(Clone, Debug)]
@@ -312,7 +311,11 @@ impl<'app> App<'app> {
 
     /// Execute DDL from users DDL file
     pub fn execute_ddl(&mut self) {
-        let ddl = load_ddl().unwrap_or_default();
+        let ddl = self.execution.load_ddl().unwrap_or_default();
+        info!("DDL: {:?}", ddl);
+        if !ddl.is_empty() {
+            self.state.sql_tab.add_ddl_to_editor(ddl.clone());
+        }
         let _ = self.event_tx().send(AppEvent::ExecuteDDL(ddl));
     }
 

--- a/src/app/state/tabs/sql.rs
+++ b/src/app/state/tabs/sql.rs
@@ -28,7 +28,7 @@ use tokio::task::JoinHandle;
 use tui_textarea::TextArea;
 
 use crate::app::ExecutionError;
-use crate::config::{load_ddl, AppConfig};
+use crate::config::AppConfig;
 
 pub fn get_keywords() -> Vec<String> {
     keywords::ALL_KEYWORDS
@@ -79,10 +79,8 @@ impl<'app> SQLTabState<'app> {
         let mut textarea = TextArea::new(empty_text);
         textarea.set_style(Style::default().fg(tailwind::WHITE));
 
-        let ddl = load_ddl().unwrap_or_default();
-        let lines = ddl.lines().map(|l| l.to_string()).collect();
-
-        let mut ddl_textarea = TextArea::new(lines);
+        let ddl_empty_text = vec!["Write your DDL here.".to_string()];
+        let mut ddl_textarea = TextArea::new(ddl_empty_text);
         ddl_textarea.set_style(Style::default().fg(tailwind::WHITE));
         if config.editor.experimental_syntax_highlighting {
             textarea.set_search_pattern(keyword_regex()).unwrap();
@@ -162,6 +160,12 @@ impl<'app> SQLTabState<'app> {
             SQLTabMode::Normal => self.editor.input(key),
             SQLTabMode::DDL => self.ddl_editor.input(key),
         };
+    }
+
+    pub fn add_ddl_to_editor(&mut self, ddl: String) {
+        self.ddl_editor.delete_line_by_end();
+        self.ddl_editor.set_yank_text(ddl);
+        self.ddl_editor.paste();
     }
 
     pub fn edit(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,11 +17,11 @@
 
 //! Configuration management handling
 
-use std::{io::Write, path::PathBuf};
+use std::path::PathBuf;
 
 use directories::{ProjectDirs, UserDirs};
 use lazy_static::lazy_static;
-use log::{error, info};
+use log::info;
 use serde::Deserialize;
 
 #[cfg(feature = "s3")]
@@ -59,55 +59,6 @@ pub fn get_data_dir() -> PathBuf {
         project_directory()
     }
 }
-
-// pub fn load_ddl() -> Option<String> {
-//     if let Some(user_dirs) = directories::UserDirs::new() {
-//         // TODO: Move to ~/.config/ddl
-//         let datafusion_rc_path = user_dirs
-//             .home_dir()
-//             .join(".datafusion")
-//             .join(".datafusionrc");
-//         let maybe_ddl = std::fs::read_to_string(datafusion_rc_path);
-//         match maybe_ddl {
-//             Ok(ddl) => {
-//                 info!("DDL: {:?}", ddl);
-//                 Some(ddl)
-//             }
-//             Err(err) => {
-//                 error!("Error reading DDL: {:?}", err);
-//                 None
-//             }
-//         }
-//     } else {
-//         info!("No user directories found");
-//         None
-//     }
-// }
-
-// pub fn save_ddl(ddl: String) {
-//     if let Some(user_dirs) = directories::UserDirs::new() {
-//         // TODO: Move to ~/.config/ddl or config defined location
-//         let datafusion_rc_path = user_dirs
-//             .home_dir()
-//             .join(".datafusion")
-//             .join(".datafusionrc");
-//         match std::fs::File::create(datafusion_rc_path) {
-//             Ok(mut f) => match f.write_all(ddl.as_bytes()) {
-//                 Ok(_) => {
-//                     info!("Saved DDL file");
-//                 }
-//                 Err(e) => {
-//                     error!("Error writing DDL file: {e}");
-//                 }
-//             },
-//             Err(e) => {
-//                 error!("Error creating or opening DDL file: {e}");
-//             }
-//         }
-//     } else {
-//         info!("No user directories found");
-//     }
-// }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct AppConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,54 +60,54 @@ pub fn get_data_dir() -> PathBuf {
     }
 }
 
-pub fn load_ddl() -> Option<String> {
-    if let Some(user_dirs) = directories::UserDirs::new() {
-        // TODO: Move to ~/.config/ddl
-        let datafusion_rc_path = user_dirs
-            .home_dir()
-            .join(".datafusion")
-            .join(".datafusionrc");
-        let maybe_ddl = std::fs::read_to_string(datafusion_rc_path);
-        match maybe_ddl {
-            Ok(ddl) => {
-                info!("DDL: {:?}", ddl);
-                Some(ddl)
-            }
-            Err(err) => {
-                error!("Error reading DDL: {:?}", err);
-                None
-            }
-        }
-    } else {
-        info!("No user directories found");
-        None
-    }
-}
+// pub fn load_ddl() -> Option<String> {
+//     if let Some(user_dirs) = directories::UserDirs::new() {
+//         // TODO: Move to ~/.config/ddl
+//         let datafusion_rc_path = user_dirs
+//             .home_dir()
+//             .join(".datafusion")
+//             .join(".datafusionrc");
+//         let maybe_ddl = std::fs::read_to_string(datafusion_rc_path);
+//         match maybe_ddl {
+//             Ok(ddl) => {
+//                 info!("DDL: {:?}", ddl);
+//                 Some(ddl)
+//             }
+//             Err(err) => {
+//                 error!("Error reading DDL: {:?}", err);
+//                 None
+//             }
+//         }
+//     } else {
+//         info!("No user directories found");
+//         None
+//     }
+// }
 
-pub fn save_ddl(ddl: String) {
-    if let Some(user_dirs) = directories::UserDirs::new() {
-        // TODO: Move to ~/.config/ddl or config defined location
-        let datafusion_rc_path = user_dirs
-            .home_dir()
-            .join(".datafusion")
-            .join(".datafusionrc");
-        match std::fs::File::create(datafusion_rc_path) {
-            Ok(mut f) => match f.write_all(ddl.as_bytes()) {
-                Ok(_) => {
-                    info!("Saved DDL file");
-                }
-                Err(e) => {
-                    error!("Error writing DDL file: {e}");
-                }
-            },
-            Err(e) => {
-                error!("Error creating or opening DDL file: {e}");
-            }
-        }
-    } else {
-        info!("No user directories found");
-    }
-}
+// pub fn save_ddl(ddl: String) {
+//     if let Some(user_dirs) = directories::UserDirs::new() {
+//         // TODO: Move to ~/.config/ddl or config defined location
+//         let datafusion_rc_path = user_dirs
+//             .home_dir()
+//             .join(".datafusion")
+//             .join(".datafusionrc");
+//         match std::fs::File::create(datafusion_rc_path) {
+//             Ok(mut f) => match f.write_all(ddl.as_bytes()) {
+//                 Ok(_) => {
+//                     info!("Saved DDL file");
+//                 }
+//                 Err(e) => {
+//                     error!("Error writing DDL file: {e}");
+//                 }
+//             },
+//             Err(e) => {
+//                 error!("Error creating or opening DDL file: {e}");
+//             }
+//         }
+//     } else {
+//         info!("No user directories found");
+//     }
+// }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct AppConfig {
@@ -210,6 +210,22 @@ pub struct ObjectStoreConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct ExecutionConfig {
     pub object_store: Option<ObjectStoreConfig>,
+    #[serde(default = "default_ddl_path")]
+    pub ddl_path: Option<PathBuf>,
+}
+
+fn default_ddl_path() -> Option<PathBuf> {
+    info!("Creating default ExecutionConfig");
+    if let Some(user_dirs) = directories::UserDirs::new() {
+        let ddl_path = user_dirs
+            .home_dir()
+            .join(".config")
+            .join("dft")
+            .join("ddl.sql");
+        Some(ddl_path)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]


### PR DESCRIPTION
Moves the DDL from `~/.datafusion/.datafusionrc` to a path defined in config (default is `~/.config/dft/ddl.sql`).  

I have a separate branch where I am working on testing the apps config and will include tests for this in that branch.