### PR TITLE
Add local benchmarking for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Some of the current and planned features are:
   - Iceberg (TODO)
   - Hudi (TODO)
 - Preloading DDL from `~/.config/dft/ddl.sql` (or a user defined path) for local database available on startup
+- Benchmarking local and FlightSQL queries with breakdown of query execution time
 - "Catalog File" support - see [#122](https://github.com/datafusion-contrib/datafusion-tui/issues/122)
   - Save table definitions *and* data
   - Save parquet metadata from remote object stores
@@ -98,6 +99,8 @@ Both of the commands above support the `--flightsql` parameter to run the SQL wi
 
 The CLI can also run your configured DDL prior to executing the query by adding the `--ddl` parameter.
 
+#### Benchmarking
+You can benchmark queries by adding the `--bench` parameter.  This will run the query a configurable number of times and output a breakdown of the queries execution time with summary statistics for each component of the query (logical planning, physical planning, execution time, and total time).  Currently only local queries can be benchmarked but benchmarking of FlightSQL queries is planned.
 
 ## `dft` FlightSQL Server
 
@@ -296,6 +299,13 @@ ddl_path = "/path/to/my/ddl.sql"
 ```
 
 Multiple `ObjectStore`s can be defined in the config file. In the future datafusion `SessionContext` and `SessionState` options can be configured here.
+
+Set the number of iterations for benchmarking queries (10 is the default).
+
+```toml
+[execution]
+benchmark_iterations = 10
+```
 
 #### Display Config
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ select * from foo where json_get(attributes, 'bar')::string='ham'
 
 ### Getting Started
 
-To have the best experience with `dft` it is highly recommended to define all of your DDL in `~/.datafusion/.datafusionrc` so that any tables you wish to query are available at startup.  Additionally, now that DataFusion supports `CREATE VIEW` via sql you can also make a `VIEW` based on these tables.
+To have the best experience with `dft` it is highly recommended to define all of your DDL in `~/.config/ddl.sql` so that any tables you wish to query are available at startup.  Additionally, now that DataFusion supports `CREATE VIEW` via sql you can also make a `VIEW` based on these tables.
 
-For example, your `~/.datafusion/.datafusionrc` file could look like the following:
+For example, your DDL file could look like the following:
 
 ```
 CREATE EXTERNAL TABLE users STORED AS NDJSON LOCATION 's3://bucket/users';
@@ -228,9 +228,9 @@ Editor for executing SQL with local DataFusion `SessionContext`.
         - `esc` to exit Edit mode and go back to Normal mode
 - DDL mode
     - Not editable
-        - `l` => load `~/.datafusion/.datafusionrc` into editor (TODO)
-        - `r` => rerun `~/.datafusion/.datafusionrc` (TODO)
-        - `w` => write editor contents to `~/.datafusion/.datafusionrc` (TODO)
+        - `l` => load configured DDL file into editor
+        - `enter` => rerun configured DDL file
+        - `s` => write editor contents to configured DDL file
     - Editable
         - Character keys to write queries
         - Backspace / tab / enter work same as normal

--- a/src/args.rs
+++ b/src/args.rs
@@ -69,6 +69,9 @@ pub struct DftArgs {
 
     #[clap(long, help = "Start a FlightSQL server")]
     pub serve: bool,
+
+    #[clap(long, short, help = "Benchmark the provided query")]
+    pub bench: bool,
 }
 
 impl DftArgs {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -178,11 +178,6 @@ impl CliApp {
         Ok(())
     }
 
-    async fn benchmark_command(&self, command: &str) -> Result<()> {
-        info!("Benchmarking command: {:?}", command);
-        Ok(())
-    }
-
     async fn benchmark_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
         info!("Benchmarking commands: {:?}", commands);
         for command in commands {
@@ -239,7 +234,7 @@ impl CliApp {
             .execution_ctx()
             .benchmark_query(sql)
             .await?;
-        println!("Stats: {:?}", stats);
+        println!("{}", stats);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -118,6 +118,10 @@ impl CliApp {
 
     async fn benchmark_files(&self, files: &[PathBuf]) -> Result<()> {
         info!("Benchmarking files: {:?}", files);
+        for file in files {
+            let query = std::fs::read_to_string(file)?;
+            self.benchmark_from_string(&query).await?;
+        }
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,54 +49,7 @@ impl CliApp {
     ///
     /// Optionally, use the FlightSQL client for execution.
     pub async fn execute_files_or_commands(&self) -> color_eyre::Result<()> {
-        #[cfg(not(feature = "flightsql"))]
-        match (
-            self.args.files.is_empty(),
-            self.args.commands.is_empty(),
-            self.args.flightsql,
-        ) {
-            (_, _, true) => Err(eyre!(
-                "FLightSQL feature isn't enabled. Reinstall `dft` with `--features=flightsql`"
-            )),
-            (true, true, _) => Err(eyre!("No files or commands provided to execute")),
-            (false, true, _) => {
-                self.execute_files(&self.args.files, self.args.run_ddl)
-                    .await
-            }
-            (true, false, _) => {
-                self.execute_commands(&self.args.commands, self.args.run_ddl)
-                    .await
-            }
-            (false, false, _) => Err(eyre!(
-                "Cannot execute both files and commands at the same time"
-            )),
-        }
-        #[cfg(feature = "flightsql")]
-        match (
-            self.args.files.is_empty(),
-            self.args.commands.is_empty(),
-            self.args.flightsql,
-        ) {
-            (true, true, _) => Err(eyre!("No files or commands provided to execute")),
-            (false, true, true) => self.flightsql_execute_files(&self.args.files).await,
-            (false, true, false) => {
-                self.execute_files(&self.args.files, self.args.run_ddl)
-                    .await
-            }
-            (true, false, true) => self.flightsql_execute_commands(&self.args.commands).await,
-            (true, false, false) => {
-                self.execute_commands(&self.args.commands, self.args.run_ddl)
-                    .await
-            }
-            (false, false, _) => Err(eyre!(
-                "Cannot execute both files and commands at the same time"
-            )),
-        }
-    }
-
-    async fn execute_files(&self, files: &[PathBuf], run_ddl: bool) -> color_eyre::Result<()> {
-        info!("Executing files: {:?}", files);
-        if run_ddl {
+        if self.args.run_ddl {
             let ddl = self.app_execution.execution_ctx().load_ddl();
             if let Some(ddl) = ddl {
                 info!("Executing DDL");
@@ -105,6 +58,57 @@ impl CliApp {
                 info!("No DDL to execute");
             }
         }
+
+        #[cfg(not(feature = "flightsql"))]
+        match (
+            self.args.files.is_empty(),
+            self.args.commands.is_empty(),
+            self.args.flightsql,
+            self.args.bench,
+        ) {
+            (_, _, true, _) => Err(eyre!(
+                "FLightSQL feature isn't enabled. Reinstall `dft` with `--features=flightsql`"
+            )),
+            (true, true, _, _) => Err(eyre!("No files or commands provided to execute")),
+            (false, true, _, false) => self.execute_files(&self.args.files).await,
+            (false, true, _, true) => self.benchmark_files(&self.args.files).await,
+            (true, false, _, false) => self.execute_commands(&self.args.commands).await,
+            (true, false, _, true) => self.benchmark_commands(&self.args.commands).await,
+            (false, false, _, false) => Err(eyre!(
+                "Cannot execute both files and commands at the same time"
+            )),
+            (false, false, false, true) => Err(eyre!("Cannot benchmark without a command or file")),
+        }
+        #[cfg(feature = "flightsql")]
+        match (
+            self.args.files.is_empty(),
+            self.args.commands.is_empty(),
+            self.args.flightsql,
+            self.args.bench,
+        ) {
+            (true, true, _, _) => Err(eyre!("No files or commands provided to execute")),
+            (false, true, true, false) => self.flightsql_execute_files(&self.args.files).await,
+            (false, true, true, true) => self.flightsql_benchmark_files(&self.args.files).await,
+            (false, true, false, false) => self.execute_files(&self.args.files).await,
+            (false, true, false, true) => self.benchmark_files(&self.args.files).await,
+
+            (true, false, true, false) => {
+                self.flightsql_execute_commands(&self.args.commands).await
+            }
+            (true, false, true, true) => {
+                self.flightsql_benchmark_commands(&self.args.commands).await
+            }
+            (true, false, false, false) => self.execute_commands(&self.args.commands).await,
+            (true, false, false, true) => self.benchmark_commands(&self.args.commands).await,
+            (false, false, false, true) => Err(eyre!("Cannot benchmark without a command or file")),
+            (false, false, _, _) => Err(eyre!(
+                "Cannot execute both files and commands at the same time"
+            )),
+        }
+    }
+
+    async fn execute_files(&self, files: &[PathBuf]) -> Result<()> {
+        info!("Executing files: {:?}", files);
         for file in files {
             self.exec_from_file(file).await?
         }
@@ -112,13 +116,25 @@ impl CliApp {
         Ok(())
     }
 
+    async fn benchmark_files(&self, files: &[PathBuf]) -> Result<()> {
+        info!("Benchmarking files: {:?}", files);
+        Ok(())
+    }
+
     #[cfg(feature = "flightsql")]
     async fn flightsql_execute_files(&self, files: &[PathBuf]) -> color_eyre::Result<()> {
-        info!("Executing files: {:?}", files);
+        info!("Executing FlightSQL files: {:?}", files);
         for (i, file) in files.iter().enumerate() {
             let file = std::fs::read_to_string(file)?;
             self.exec_from_flightsql(file, i).await?;
         }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "flightsql")]
+    async fn flightsql_benchmark_files(&self, files: &[PathBuf]) -> Result<()> {
+        info!("Benchmarking FlightSQL files: {:?}", files);
 
         Ok(())
     }
@@ -153,17 +169,8 @@ impl CliApp {
         Ok(())
     }
 
-    async fn execute_commands(&self, commands: &[String], run_ddl: bool) -> color_eyre::Result<()> {
+    async fn execute_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
         info!("Executing commands: {:?}", commands);
-        if run_ddl {
-            let ddl = self.app_execution.execution_ctx().load_ddl();
-            if let Some(ddl) = ddl {
-                info!("Executing DDL");
-                self.exec_from_string(&ddl).await?;
-            } else {
-                info!("No DDL to execute");
-            }
-        }
         for command in commands {
             self.exec_from_string(command).await?
         }
@@ -171,12 +178,32 @@ impl CliApp {
         Ok(())
     }
 
+    async fn benchmark_command(&self, command: &str) -> Result<()> {
+        info!("Benchmarking command: {:?}", command);
+        Ok(())
+    }
+
+    async fn benchmark_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
+        info!("Benchmarking commands: {:?}", commands);
+        for command in commands {
+            self.benchmark_from_string(command).await?;
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "flightsql")]
     async fn flightsql_execute_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
-        info!("Executing commands: {:?}", commands);
+        info!("Executing FlightSQL commands: {:?}", commands);
         for (i, command) in commands.iter().enumerate() {
             self.exec_from_flightsql(command.to_string(), i).await?
         }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "flightsql")]
+    async fn flightsql_benchmark_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
+        info!("Benchmark FlightSQL commands: {:?}", commands);
 
         Ok(())
     }
@@ -203,6 +230,16 @@ impl CliApp {
                 self.print_any_stream(stream).await;
             }
         }
+        Ok(())
+    }
+
+    async fn benchmark_from_string(&self, sql: &str) -> color_eyre::Result<()> {
+        let stats = self
+            .app_execution
+            .execution_ctx()
+            .benchmark_query(sql)
+            .await?;
+        println!("Stats: {:?}", stats);
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,13 +159,13 @@ pub struct ObjectStoreConfig {
     pub s3: Option<Vec<S3Config>>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ExecutionConfig {
     pub object_store: Option<ObjectStoreConfig>,
     #[serde(default = "default_ddl_path")]
     pub ddl_path: Option<PathBuf>,
     #[serde(default = "default_benchmark_iterations")]
-    pub benchmark_iterations: Option<usize>,
+    pub benchmark_iterations: usize,
 }
 
 fn default_ddl_path() -> Option<PathBuf> {
@@ -182,8 +182,18 @@ fn default_ddl_path() -> Option<PathBuf> {
     }
 }
 
-fn default_benchmark_iterations() -> Option<usize> {
-    Some(10)
+fn default_benchmark_iterations() -> usize {
+    10
+}
+
+impl Default for ExecutionConfig {
+    fn default() -> Self {
+        Self {
+            object_store: None,
+            ddl_path: default_ddl_path(),
+            benchmark_iterations: default_benchmark_iterations(),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,8 @@ pub struct ExecutionConfig {
     pub object_store: Option<ObjectStoreConfig>,
     #[serde(default = "default_ddl_path")]
     pub ddl_path: Option<PathBuf>,
+    #[serde(default = "default_benchmark_iterations")]
+    pub benchmark_iterations: Option<usize>,
 }
 
 fn default_ddl_path() -> Option<PathBuf> {
@@ -178,6 +180,10 @@ fn default_ddl_path() -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+fn default_benchmark_iterations() -> Option<usize> {
+    Some(10)
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -47,20 +47,22 @@ pub struct DurationsSummary {
     pub max: Duration,
     pub mean: Duration,
     pub median: Duration,
+    pub percent_of_total: f64,
 }
 
 impl std::fmt::Display for DurationsSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Min: {:?}", self.min)?;
         writeln!(f, "Max: {:?}", self.max)?;
-        writeln!(f, "Mean: {:?}", self.mean)?;
-        writeln!(f, "Median: {:?}", self.median)
+        writeln!(f, "Median: {:?}", self.median)?;
+        writeln!(f, "Mean: {:?} ({:.2}%)", self.mean, self.percent_of_total)
     }
 }
 
 /// Contains stats for all runs of a benchmarked query and provides methods for aggregating
 #[derive(Debug, Default)]
 pub struct BenchmarkStats {
+    query: String,
     runs: usize,
     logical_planning_durations: Vec<Duration>,
     physical_planning_durations: Vec<Duration>,
@@ -70,6 +72,7 @@ pub struct BenchmarkStats {
 
 impl BenchmarkStats {
     fn new(
+        query: String,
         logical_planning_durations: Vec<Duration>,
         physical_planning_durations: Vec<Duration>,
         execution_durations: Vec<Duration>,
@@ -77,6 +80,7 @@ impl BenchmarkStats {
     ) -> Self {
         let runs = logical_planning_durations.len();
         Self {
+            query,
             runs,
             logical_planning_durations,
             physical_planning_durations,
@@ -85,7 +89,7 @@ impl BenchmarkStats {
         }
     }
 
-    fn summarize(durations: &[Duration]) -> DurationsSummary {
+    fn summarize(&self, durations: &[Duration]) -> DurationsSummary {
         let mut sorted = durations.to_vec();
         sorted.sort();
         let len = sorted.len();
@@ -93,11 +97,21 @@ impl BenchmarkStats {
         let max = *sorted.last().unwrap();
         let mean = sorted.iter().sum::<Duration>() / len as u32;
         let median = sorted[len / 2];
+        let this_total = durations.iter().map(|d| d.as_nanos()).sum::<u128>();
+        let total_duration = self
+            .total_durations
+            .iter()
+            .map(|d| d.as_nanos())
+            .sum::<u128>();
+        let percent_of_total = (this_total as f64 / total_duration as f64) * 100.0;
+        // let percent_of_total =
+        //     (this_total.as_nanos() as f64 / total_duration.as_nanos() as f64) * 100.0;
         DurationsSummary {
             min,
             max,
             mean,
             median,
+            percent_of_total,
         }
     }
 }
@@ -108,21 +122,22 @@ impl std::fmt::Display for BenchmarkStats {
         writeln!(f, "----------------------------")?;
         writeln!(f, "Benchmark Stats ({} runs)", self.runs)?;
         writeln!(f, "----------------------------")?;
+        writeln!(f, "{}", self.query)?;
+        writeln!(f, "----------------------------")?;
 
-        let logical_planning_summary = BenchmarkStats::summarize(&self.logical_planning_durations);
+        let logical_planning_summary = self.summarize(&self.logical_planning_durations);
         writeln!(f, "Logical Planning")?;
         writeln!(f, "{}", logical_planning_summary)?;
 
-        let physical_planning_summary =
-            BenchmarkStats::summarize(&self.physical_planning_durations);
+        let physical_planning_summary = self.summarize(&self.physical_planning_durations);
         writeln!(f, "Physical Planning")?;
         writeln!(f, "{}", physical_planning_summary)?;
 
-        let execution_summary = BenchmarkStats::summarize(&self.execution_durations);
+        let execution_summary = self.summarize(&self.execution_durations);
         writeln!(f, "Execution")?;
         writeln!(f, "{}", execution_summary)?;
 
-        let total_summary = BenchmarkStats::summarize(&self.total_durations);
+        let total_summary = self.summarize(&self.total_durations);
         writeln!(f, "Total")?;
         writeln!(f, "{}", total_summary)
     }
@@ -378,31 +393,29 @@ impl ExecutionContext {
             let statements = DFParser::parse_sql_with_dialect(query, &dialect)?;
             if statements.len() == 1 {
                 for _ in 0..iterations {
-                    let start = std::time::Instant::now();
                     let statement = statements[0].clone();
-                    let logical_planning_start = std::time::Instant::now();
+                    let start = std::time::Instant::now();
                     let logical_plan = self
                         .session_ctx()
                         .state()
                         .statement_to_plan(statement)
                         .await?;
-                    let logical_planning_duration = logical_planning_start.elapsed();
-                    let physical_planning_start = std::time::Instant::now();
+                    let logical_planning_duration = start.elapsed();
                     let physical_plan = self
                         .session_ctx()
                         .state()
                         .create_physical_plan(&logical_plan)
                         .await?;
-                    let physical_planning_duration = physical_planning_start.elapsed();
+                    let physical_planning_duration = start.elapsed();
                     let task_ctx = self.session_ctx().task_ctx();
                     let mut stream = execute_stream(physical_plan, task_ctx)?;
-                    let execution_start = std::time::Instant::now();
                     while stream.next().await.is_some() {}
-                    let execution_duration = execution_start.elapsed();
+                    let execution_duration = start.elapsed();
                     let total_duration = start.elapsed();
                     logical_planning_durations.push(logical_planning_duration);
-                    physical_planning_durations.push(physical_planning_duration);
-                    execution_durations.push(execution_duration);
+                    physical_planning_durations
+                        .push(physical_planning_duration - logical_planning_duration);
+                    execution_durations.push(execution_duration - physical_planning_duration);
                     total_durations.push(total_duration);
                 }
             } else {
@@ -410,6 +423,7 @@ impl ExecutionContext {
             }
 
             Ok(BenchmarkStats::new(
+                query.to_string(),
                 logical_planning_durations,
                 physical_planning_durations,
                 execution_durations,

--- a/tests/cli_cases/bench.rs
+++ b/tests/cli_cases/bench.rs
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests for the CLI (e.g. run from files)
+
+use assert_cmd::Command;
+
+use super::{contains_str, sql_in_file};
+
+#[test]
+fn test_bench_command() {
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-c")
+        .arg("SELECT 1")
+        .arg("--bench")
+        .assert()
+        .success();
+
+    let expected = r##"
+----------------------------
+Benchmark Stats (10 runs)
+----------------------------
+SELECT 1
+----------------------------"##;
+    assert.stdout(contains_str(expected));
+}
+
+#[test]
+fn test_bench_files() {
+    let file = sql_in_file(r#"SELECT 1 + 1;"#);
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(file.path())
+        .arg("--bench")
+        .assert()
+        .success();
+
+    let expected_err = r##"
+----------------------------
+Benchmark Stats (10 runs)
+----------------------------
+SELECT 1 + 1;
+----------------------------"##;
+    assert.code(0).stdout(contains_str(expected_err));
+}

--- a/tests/cli_cases/mod.rs
+++ b/tests/cli_cases/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 mod basic;
+mod bench;
 mod config;
 
 use assert_cmd::Command;


### PR DESCRIPTION
Adds `--bench` param that can be used with the CLI.  Runs the provided command or files a specified number of times (configurable in the the execution config of config file) and reports summary statistics on the planning and execution times.  The same machinery here (within `ExecutionContext`) will be used to add a benchmark mode to the TUI where the results will be visualized with a histogram.

I will have follow on PRs for adding benchmark mode to TUI and for adding FlightSQL benchmarking which will take a different approach (i.e. rather than planning times it will time how long each GRPC call takes).

Remaining items:
- [x] Aggregate statistics for output
- [x] Display aggregate statistics
- [x] Add tests