### PR TITLE
Add `--run-before` param to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The CLI can also run your configured DDL prior to executing the query by adding 
 #### Benchmarking
 You can benchmark queries by adding the `--bench` parameter.  This will run the query a configurable number of times and output a breakdown of the queries execution time with summary statistics for each component of the query (logical planning, physical planning, execution time, and total time).
 
+Optionally you can use the `--run-before` param to run a query before the benchmark is run.  This is useful in cases where you want to hit a temp table or write a file to disk that your benchmark query will use.
+
 ## `dft` FlightSQL Server
 
 The `dft` FlightSQL server (feature flag `experimental-flightsql-server`) is a Flight service that can be used to execute SQL queries against DataFusion.  The server is started by running `dft --serve` and can optionally run your configured DDL with the `--run-ddl` parameter.

--- a/src/args.rs
+++ b/src/args.rs
@@ -72,6 +72,9 @@ pub struct DftArgs {
 
     #[clap(long, short, help = "Benchmark the provided query")]
     pub bench: bool,
+
+    #[clap(long, help = "Run the provided query before running the benchmark")]
+    pub run_before: Option<String>,
 }
 
 impl DftArgs {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,6 +111,12 @@ impl CliApp {
     }
 
     async fn benchmark_files(&self, files: &[PathBuf]) -> Result<()> {
+        if let Some(run_before_query) = &self.args.run_before {
+            self.app_execution
+                .execution_ctx()
+                .execute_sql_and_discard_results(run_before_query)
+                .await?;
+        }
         info!("Benchmarking files: {:?}", files);
         for file in files {
             let query = std::fs::read_to_string(file)?;
@@ -181,6 +187,12 @@ impl CliApp {
     }
 
     async fn benchmark_commands(&self, commands: &[String]) -> color_eyre::Result<()> {
+        if let Some(run_before_query) = &self.args.run_before {
+            self.app_execution
+                .execution_ctx()
+                .execute_sql_and_discard_results(run_before_query)
+                .await?;
+        }
         info!("Benchmarking commands: {:?}", commands);
         for command in commands {
             self.benchmark_from_string(command).await?;

--- a/tests/cli_cases/bench.rs
+++ b/tests/cli_cases/bench.rs
@@ -60,3 +60,47 @@ SELECT 1 + 1;
 ----------------------------"##;
     assert.code(0).stdout(contains_str(expected_err));
 }
+
+#[test]
+fn test_bench_command_with_run_before() {
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-c")
+        .arg("SELECT * FROM t")
+        .arg("--bench")
+        .arg("--run-before")
+        .arg("CREATE TABLE t AS VALUES (1)")
+        .assert()
+        .success();
+
+    let expected = r##"
+----------------------------
+Benchmark Stats (10 runs)
+----------------------------
+SELECT * FROM t
+----------------------------"##;
+    assert.stdout(contains_str(expected));
+}
+
+#[test]
+fn test_bench_files_with_run_before() {
+    let file = sql_in_file(r#"SELECT * FROM t;"#);
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(file.path())
+        .arg("--bench")
+        .arg("--run-before")
+        .arg("CREATE TABLE t AS VALUES (1)")
+        .assert()
+        .success();
+
+    let expected_err = r##"
+----------------------------
+Benchmark Stats (10 runs)
+----------------------------
+SELECT * FROM t;
+----------------------------"##;
+    assert.code(0).stdout(contains_str(expected_err));
+}

--- a/tests/cli_cases/config.rs
+++ b/tests/cli_cases/config.rs
@@ -93,7 +93,6 @@ fn test_custom_config_benchmark_iterations() {
     let mut config_builder = TestConfigBuilder::default();
     config_builder.with_benchmark_iterations(5);
     let config = config_builder.build("my_config.toml");
-    println!("Test config: {:?}", config);
 
     let assert = Command::cargo_bin("dft")
         .unwrap()

--- a/tests/extension_cases/flightsql.rs
+++ b/tests/extension_cases/flightsql.rs
@@ -319,7 +319,6 @@ async fn test_custom_config_benchmark_iterations() {
     let mut config_builder = TestConfigBuilder::default();
     config_builder.with_flightsql_benchmark_iterations(5);
     let config = config_builder.build("my_config.toml");
-    println!("Test config: {:?}", config);
 
     let assert = tokio::task::spawn_blocking(move || {
         Command::cargo_bin("dft")


### PR DESCRIPTION
Lets you run a command prior to running benchmark.  Useful for creating mem tables or writing files to disk and then running benchmark on that.