### PR TITLE
Add `DedicatedExecutor` to FlightSQL Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "log",
+ "num_cpus",
  "object_store",
  "parking_lot",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "lazy_static",
  "log",
  "object_store",
+ "parking_lot",
  "pin-project-lite",
  "predicates",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.13.0"
 lazy_static = "1.4.0"
 log = "0.4.22"
 object_store = { version = "0.10.2", features = ["aws"], optional = true }
+parking_lot = "0.12.3"
 pin-project-lite = {version = "0.2.14" }
 prost = "0.12.3"
 ratatui = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ http-body = {version = "0.4.5" }
 itertools = "0.13.0"
 lazy_static = "1.4.0"
 log = "0.4.22"
+num_cpus = "1.16.0"
 object_store = { version = "0.10.2", features = ["aws"], optional = true }
 parking_lot = "0.12.3"
 pin-project-lite = {version = "0.2.14" }

--- a/f.csv
+++ b/f.csv
@@ -1,2 +1,0 @@
-query,runs,get_flight_info_min,get_flight_info_max,get_flight_info_mean,get_flight_info_median,get_flight_info_percent_of_total,ttfb_min,ttfb_max,ttfb,mean,ttfb_median,ttfb_percent_of_total,do_get_min,do_get_max,do_get_mean,do_get_median,do_get_percent_of_total,total_min,total_max,total_mean,total_median,total_percent_of_total
-SELECT 1,10,7,28,11,9,33.44,9,127,22,10,66.29,9,127,22,10,66.43,17,139,33,19,100.00

--- a/src/args.rs
+++ b/src/args.rs
@@ -91,7 +91,7 @@ pub struct DftArgs {
     #[clap(short = 'n', help = "Set the number of benchmark iterations to run")]
     pub benchmark_iterations: Option<usize>,
 
-    #[cfg(feature = "flightsql")]
+    #[cfg(any(feature = "flightsql", feature = "experimental-flightsql-server"))]
     #[clap(long, help = "Set the host and port to be used for FlightSQL")]
     pub flightsql_host: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,8 @@ pub struct ExecutionConfig {
     pub flightsql_server_batch_size: usize,
     #[serde(default = "default_dedicated_executor_enabled")]
     pub dedicated_executor_enabled: bool,
+    #[serde(default = "default_dedicated_executor_threads_percent")]
+    pub dedicated_executor_threads_percent: f64,
 }
 
 fn default_ddl_path() -> Option<PathBuf> {
@@ -210,6 +212,10 @@ fn default_dedicated_executor_enabled() -> bool {
     false
 }
 
+fn default_dedicated_executor_threads_percent() -> f64 {
+    0.75
+}
+
 impl Default for ExecutionConfig {
     fn default() -> Self {
         Self {
@@ -220,6 +226,7 @@ impl Default for ExecutionConfig {
             tui_batch_size: default_tui_batch_size(),
             flightsql_server_batch_size: default_flightsql_server_batch_size(),
             dedicated_executor_enabled: default_dedicated_executor_enabled(),
+            dedicated_executor_threads_percent: default_dedicated_executor_threads_percent(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,6 +172,8 @@ pub struct ExecutionConfig {
     pub tui_batch_size: usize,
     #[serde(default = "default_flightsql_server_batch_size")]
     pub flightsql_server_batch_size: usize,
+    #[serde(default = "default_dedicated_executor_enabled")]
+    pub dedicated_executor_enabled: bool,
 }
 
 fn default_ddl_path() -> Option<PathBuf> {
@@ -204,6 +206,10 @@ fn default_flightsql_server_batch_size() -> usize {
     8092
 }
 
+fn default_dedicated_executor_enabled() -> bool {
+    false
+}
+
 impl Default for ExecutionConfig {
     fn default() -> Self {
         Self {
@@ -213,6 +219,7 @@ impl Default for ExecutionConfig {
             cli_batch_size: default_cli_batch_size(),
             tui_batch_size: default_tui_batch_size(),
             flightsql_server_batch_size: default_flightsql_server_batch_size(),
+            dedicated_executor_enabled: default_dedicated_executor_enabled(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,8 +174,8 @@ pub struct ExecutionConfig {
     pub flightsql_server_batch_size: usize,
     #[serde(default = "default_dedicated_executor_enabled")]
     pub dedicated_executor_enabled: bool,
-    #[serde(default = "default_dedicated_executor_threads_percent")]
-    pub dedicated_executor_threads_percent: f64,
+    #[serde(default = "default_dedicated_executor_threads")]
+    pub dedicated_executor_threads: usize,
 }
 
 fn default_ddl_path() -> Option<PathBuf> {
@@ -212,8 +212,12 @@ fn default_dedicated_executor_enabled() -> bool {
     false
 }
 
-fn default_dedicated_executor_threads_percent() -> f64 {
-    0.75
+fn default_dedicated_executor_threads() -> usize {
+    // By default we slightly over provision CPUs.  For example, if you have N CPUs available we
+    // have N CPUs for the [`DedicatedExecutor`] and 1 for the main / IO runtime.
+    //
+    // Ref: https://github.com/datafusion-contrib/datafusion-dft/pull/247#discussion_r1848270250
+    num_cpus::get()
 }
 
 impl Default for ExecutionConfig {
@@ -226,7 +230,7 @@ impl Default for ExecutionConfig {
             tui_batch_size: default_tui_batch_size(),
             flightsql_server_batch_size: default_flightsql_server_batch_size(),
             dedicated_executor_enabled: default_dedicated_executor_enabled(),
-            dedicated_executor_threads_percent: default_dedicated_executor_threads_percent(),
+            dedicated_executor_threads: default_dedicated_executor_threads(),
         }
     }
 }

--- a/src/execution/dedicated_executor.rs
+++ b/src/execution/dedicated_executor.rs
@@ -1,0 +1,333 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    sync::{Arc, OnceLock, RwLock},
+    time::Duration,
+};
+
+use futures::{
+    future::{BoxFuture, Shared},
+    FutureExt,
+};
+use log::warn;
+use tokio::{
+    runtime::Handle,
+    sync::{oneshot::error::RecvError, Notify},
+};
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 5);
+
+/// Manages a separate tokio runtime (thread pool) for executing tasks.
+///
+/// A `DedicatedExecutor` runs futures (and any `tasks` that are
+/// `tokio::task::spawned` by them) on a separate tokio Executor
+///
+/// # Background
+///
+/// Tokio has the notion of the "current" runtime, which runs the current future
+/// and any tasks spawned by it. Typically, this is the runtime created by
+/// `tokio::main` and is used for the main application logic and I/O handling
+///
+/// For CPU bound work, such as DataFusion plan execution, it is important to
+/// run on a separate thread pool to avoid blocking the I/O handling for extended
+/// periods of time in order to avoid long poll latencies (which decreases the
+/// throughput of small requests under concurrent load).
+///
+/// # IO Scheduling
+///
+/// I/O, such as network calls, should not be performed on the runtime managed
+/// by [`DedicatedExecutor`]. As tokio is a cooperative scheduler, long-running
+/// CPU tasks will not be preempted and can therefore starve servicing of other
+/// tasks. This manifests in long poll-latencies, where a task is ready to run
+/// but isn't being scheduled to run. For CPU-bound work this isn't a problem as
+/// there is no external party waiting on a response, however, for I/O tasks,
+/// long poll latencies can prevent timely servicing of IO, which can have a
+/// significant detrimental effect.
+///
+/// # Details
+///
+/// The worker thread priority is set to low so that such tasks do
+/// not starve other more important tasks (such as answering health checks)
+///
+/// Follows the example from stack overflow and spawns a new
+/// thread to install a Tokio runtime "context"
+/// <https://stackoverflow.com/questions/62536566>
+///
+/// # Trouble Shooting:
+///
+/// ## "No IO runtime registered. Call `register_io_runtime`/`register_current_runtime_for_io` in current thread!
+///
+/// This means that IO was attempted on a tokio runtime that was not registered
+/// for IO. One solution is to run the task using [DedicatedExecutor::spawn].
+///
+/// ## "Cannot drop a runtime in a context where blocking is not allowed"`
+///
+/// If you try to use this structure from an async context you see something like
+/// thread 'plan::stringset::tests::test_builder_plan' panicked at 'Cannot
+/// drop a runtime in a context where blocking is not allowed. This
+/// happens when a runtime is dropped from within an asynchronous
+/// context.', .../tokio-1.4.0/src/runtime/blocking/shutdown.rs:51:21
+struct DedicatedExecutor {
+    state: Arc<RwLock<State>>,
+}
+
+/// [`DedicatedExecutor`] for testing purposes.
+static TESTING_EXECUTOR: OnceLock<DedicatedExecutor> = OnceLock::new();
+
+impl DedicatedExecutor {
+    /// Creates a new `DedicatedExecutor` with a dedicated tokio
+    /// executor that is separate from the threadpool created via
+    /// `[tokio::main]` or similar.
+    ///
+    /// See the documentation on [`DedicatedExecutor`] for more details.
+    ///
+    /// If [`DedicatedExecutor::new`] is called from an existing tokio runtime,
+    /// it will assume that the existing runtime should be used for I/O, and is
+    /// thus set, via [`register_io_runtime`] by all threads spawned by the
+    /// executor. This will allow scheduling IO outside the context of
+    /// [`DedicatedExecutor`] using [`spawn_io`].
+    pub fn new(name: &str, runtime_builder: tokio::runtime::Builder) -> Self {
+        Self::new_inner(name, runtime_builder, false)
+    }
+
+    fn new_inner(name: &str, runtime_builder: tokio::runtime::Builder, testing: bool) -> Self {
+        let name = name.to_owned();
+
+        let notify_shutdown = Arc::new(Notify::new());
+        let notify_shutdown_captured = Arc::clone(&notify_shutdown);
+
+        let (tx_shutdown, rx_shutdown) = tokio::sync::oneshot::channel();
+        let (tx_handle, rx_handle) = std::sync::mpsc::channel();
+
+        let io_handle = tokio::runtime::Handle::try_current().ok();
+        let thread = std::thread::Builder::new()
+            .name(format!("{name} driver"))
+            .spawn(move || {
+                // also register the IO runtime for the current thread, since it might be used as well (esp. for the
+                // current thread RT)
+                register_io_runtime(io_handle.clone());
+
+                let mut runtime_builder = runtime_builder;
+                let runtime = runtime_builder
+                    .on_thread_start(move || register_io_runtime(io_handle.clone()))
+                    .build()
+                    .expect("Creating tokio runtime");
+
+                runtime.block_on(async move {
+                    // Enable the "notified" receiver BEFORE sending the runtime handle back to the constructor thread
+                    // (i.e .the one that runs `new`) to avoid the potential (but unlikely) race that the shutdown is
+                    // started right after the constructor finishes and the new runtime calls
+                    // `notify_shutdown_captured.notified().await`.
+                    //
+                    // Tokio provides an API for that by calling `enable` on the `notified` future (this requires
+                    // pinning though).
+                    let shutdown = notify_shutdown_captured.notified();
+                    let mut shutdown = std::pin::pin!(shutdown);
+                    shutdown.as_mut().enable();
+
+                    if tx_handle.send(Handle::current()).is_err() {
+                        return;
+                    }
+                    shutdown.await;
+                });
+
+                runtime.shutdown_timeout(SHUTDOWN_TIMEOUT);
+
+                // send shutdown "done" signal
+                tx_shutdown.send(()).ok();
+            })
+            .expect("executor setup");
+
+        let handle = rx_handle.recv().expect("driver started");
+
+        let state = State {
+            handle: Some(handle),
+            start_shutdown: notify_shutdown,
+            completed_shutdown: rx_shutdown.map_err(Arc::new).boxed().shared(),
+            thread: Some(thread),
+        };
+
+        Self {
+            state: Arc::new(RwLock::new(state)),
+            testing,
+        }
+    }
+
+    /// Create new executor for testing purposes.
+    ///
+    /// Internal state may be shared with other tests.
+    pub fn new_testing() -> Self {
+        TESTING_EXECUTOR
+            .get_or_init(|| {
+                let mut runtime_builder = tokio::runtime::Builder::new_current_thread();
+
+                // only enable `time` but NOT the IO integration since IO shouldn't run on the DataFusion runtime
+                // See:
+                // - https://github.com/influxdata/influxdb_iox/issues/10803
+                // - https://github.com/influxdata/influxdb_iox/pull/11030
+                runtime_builder.enable_time();
+
+                Self::new_inner(
+                    "testing",
+                    runtime_builder,
+                    Arc::new(Registry::default()),
+                    true,
+                )
+            })
+            .clone()
+    }
+
+    /// Runs the specified [`Future`] (and any tasks it spawns) on the thread
+    /// pool managed by this `DedicatedExecutor`.
+    ///
+    /// # Notes
+    ///
+    /// UNLIKE [`tokio::task::spawn`], the returned future is **cancelled** when
+    /// it is dropped. Thus, you need ensure the returned future lives until it
+    /// completes (call `await`) or you wish to cancel it.
+    ///
+    /// Currently all tasks are added to the tokio executor immediately and
+    /// compete for the threadpool's resources.
+    pub fn spawn<T>(&self, task: T) -> impl Future<Output = Result<T::Output, JobError>>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        let handle = {
+            let state = self.state.read();
+            state.handle.clone()
+        };
+
+        let Some(handle) = handle else {
+            return futures::future::err(JobError::WorkerGone).boxed();
+        };
+
+        // use JoinSet implement "cancel on drop"
+        let mut join_set = JoinSet::new();
+        join_set.spawn_on(task, &handle);
+        async move {
+            join_set
+                .join_next()
+                .await
+                .expect("just spawned task")
+                .map_err(|e| match e.try_into_panic() {
+                    Ok(e) => {
+                        let s = if let Some(s) = e.downcast_ref::<String>() {
+                            s.clone()
+                        } else if let Some(s) = e.downcast_ref::<&str>() {
+                            s.to_string()
+                        } else {
+                            "unknown internal error".to_string()
+                        };
+
+                        JobError::Panic { msg: s }
+                    }
+                    Err(_) => JobError::WorkerGone,
+                })
+        }
+        .boxed()
+    }
+
+    /// signals shutdown of this executor and any Clones
+    pub fn shutdown(&self) {
+        if self.testing {
+            return;
+        }
+
+        // hang up the channel which will cause the dedicated thread
+        // to quit
+        let mut state = self.state.write();
+        state.handle = None;
+        state.start_shutdown.notify_one();
+    }
+
+    /// Stops all subsequent task executions, and waits for the worker
+    /// thread to complete. Note this will shutdown all clones of this
+    /// `DedicatedExecutor` as well.
+    ///
+    /// Only the first all to `join` will actually wait for the
+    /// executing thread to complete. All other calls to join will
+    /// complete immediately.
+    ///
+    /// # Panic / Drop
+    /// [`DedicatedExecutor`] implements shutdown on [`Drop`]. You should just use this behavior and NOT call
+    /// [`join`](Self::join) manually during [`Drop`] or panics because this might lead to another panic, see
+    /// <https://github.com/rust-lang/futures-rs/issues/2575>.
+    pub async fn join(&self) {
+        if self.testing {
+            return;
+        }
+
+        self.shutdown();
+
+        // get handle mutex is held
+        let handle = {
+            let state = self.state.read();
+            state.completed_shutdown.clone()
+        };
+
+        // wait for completion while not holding the mutex to avoid
+        // deadlocks
+        handle.await.expect("Thread died?")
+    }
+}
+
+/// Runs futures (and any `tasks` that are `tokio::task::spawned` by
+/// them) on a separate tokio Executor.
+///
+/// The state is only used by the "outer" API, not by the newly created runtime. The new runtime waits for
+/// [`start_shutdown`](Self::start_shutdown) and signals the completion via
+/// [`completed_shutdown`](Self::completed_shutdown) (for which is owns the sender side).
+struct State {
+    /// Runtime handle.
+    ///
+    /// This is `None` when the executor is shutting down.
+    handle: Option<Handle>,
+
+    /// If notified, the executor tokio runtime will begin to shutdown.
+    ///
+    /// We could implement this by checking `handle.is_none()` in regular intervals but requires regular wake-ups and
+    /// locking of the state. Just using a proper async signal is nicer.
+    start_shutdown: Arc<Notify>,
+
+    /// Receiver side indicating that shutdown is complete.
+    completed_shutdown: Shared<BoxFuture<'static, Result<(), Arc<RecvError>>>>,
+
+    /// The inner thread that can be used to join during drop.
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+// IMPORTANT: Implement `Drop` for `State`, NOT for `DedicatedExecutor`, because the executor can be cloned and clones
+// share their inner state.
+impl Drop for State {
+    fn drop(&mut self) {
+        if self.handle.is_some() {
+            warn!("DedicatedExecutor dropped without calling shutdown()");
+            self.handle = None;
+            self.start_shutdown.notify_one();
+        }
+
+        // do NOT poll the shared future if we are panicking due to https://github.com/rust-lang/futures-rs/issues/2575
+        if !std::thread::panicking() && self.completed_shutdown.clone().now_or_never().is_none() {
+            warn!("DedicatedExecutor dropped without waiting for worker termination",);
+        }
+
+        // join thread but don't care about the results
+        self.thread.take().expect("not dropped yet").join().ok();
+    }
+}

--- a/src/execution/executor/dedicated.rs
+++ b/src/execution/executor/dedicated.rs
@@ -25,7 +25,7 @@ use futures::{
     future::{BoxFuture, Shared},
     Future, FutureExt, TryFutureExt,
 };
-use log::warn;
+use log::{info, warn};
 use parking_lot::RwLock;
 use tokio::{
     runtime::Handle,
@@ -166,6 +166,8 @@ impl DedicatedExecutor {
                 let cpus = num_cpus::get();
                 let cpu_threads =
                     (config.dedicated_executor_threads_percent * cpus as f64) as usize;
+
+                info!("Creating DedicatedExecutor with {cpu_threads} threads");
 
                 let mut runtime_builder = runtime_builder;
                 let runtime = runtime_builder

--- a/src/execution/executor/dedicated.rs
+++ b/src/execution/executor/dedicated.rs
@@ -163,15 +163,14 @@ impl DedicatedExecutor {
                 // current thread RT)
                 register_io_runtime(io_handle.clone());
 
-                let cpus = num_cpus::get();
-                let cpu_threads =
-                    (config.dedicated_executor_threads_percent * cpus as f64) as usize;
-
-                info!("Creating DedicatedExecutor with {cpu_threads} threads");
+                info!(
+                    "Creating DedicatedExecutor with {} threads",
+                    config.dedicated_executor_threads
+                );
 
                 let mut runtime_builder = runtime_builder;
                 let runtime = runtime_builder
-                    .worker_threads(cpu_threads)
+                    .worker_threads(config.dedicated_executor_threads)
                     .on_thread_start(move || register_io_runtime(io_handle.clone()))
                     .build()
                     .expect("Creating tokio runtime");

--- a/src/execution/executor/dedicated.rs
+++ b/src/execution/executor/dedicated.rs
@@ -32,7 +32,17 @@ use tokio::{
     task::JoinSet,
 };
 
+use super::io::register_io_runtime;
+
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 5);
+
+/// Errors occurring when polling [`DedicatedExecutor::spawn`].
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum JobError {
+    WorkerGone,
+    Panic { msg: String },
+}
 
 /// Manages a separate tokio runtime (thread pool) for executing tasks.
 ///
@@ -84,6 +94,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 5);
 /// drop a runtime in a context where blocking is not allowed. This
 /// happens when a runtime is dropped from within an asynchronous
 /// context.', .../tokio-1.4.0/src/runtime/blocking/shutdown.rs:51:21
+#[derive(Clone)]
 struct DedicatedExecutor {
     state: Arc<RwLock<State>>,
 

--- a/src/execution/executor/io.rs
+++ b/src/execution/executor/io.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    cell::RefCell,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    future::{BoxFuture, Shared},
+    Future, FutureExt, TryFutureExt,
+};
+use tokio::{runtime::Handle, task::JoinHandle};
+
+thread_local! {
+    /// Tokio runtime `Handle` for doing network (I/O) operations, see [`spawn_io`]
+    pub static IO_RUNTIME: RefCell<Option<Handle>> = const { RefCell::new(None) };
+}
+
+/// Registers `handle` as the IO runtime for this thread
+///
+/// See [`spawn_io`]
+pub fn register_io_runtime(handle: Option<Handle>) {
+    IO_RUNTIME.set(handle)
+}
+
+/// Runs `fut` on the runtime registered by [`register_io_runtime`] if any,
+/// otherwise awaits on the current thread
+///
+/// # Panic
+/// Needs a IO runtime [registered](register_io_runtime).
+pub async fn spawn_io<Fut>(fut: Fut) -> Fut::Output
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send,
+{
+    let h = IO_RUNTIME.with_borrow(|h| h.clone()).expect(
+        "No IO runtime registered. If you hit this panic, it likely \
+            means a DataFusion plan or other CPU bound work is running on the \
+            a tokio threadpool used for IO. Try spawning the work using \
+            `DedicatedExcutor::spawn` or for tests `register_current_runtime_for_io`",
+    );
+    DropGuard(h.spawn(fut)).await
+}
+
+struct DropGuard<T>(JoinHandle<T>);
+impl<T> Drop for DropGuard<T> {
+    fn drop(&mut self) {
+        self.0.abort()
+    }
+}
+
+impl<T> Future for DropGuard<T> {
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(match std::task::ready!(self.0.poll_unpin(cx)) {
+            Ok(v) => v,
+            Err(e) if e.is_cancelled() => panic!("IO runtime was shut down"),
+            Err(e) => std::panic::resume_unwind(e.into_panic()),
+        })
+    }
+}

--- a/src/execution/executor/mod.rs
+++ b/src/execution/executor/mod.rs
@@ -1,2 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// A majority of the code in this module was copied from InfluxDB
+///
+/// Ref: https://github.com/influxdata/influxdb3_core/tree/6fcbb004232738d55655f32f4ad2385523d10696/executor
 pub mod dedicated;
 pub mod io;

--- a/src/execution/executor/mod.rs
+++ b/src/execution/executor/mod.rs
@@ -1,0 +1,2 @@
+pub mod dedicated;
+pub mod io;

--- a/src/execution/local.rs
+++ b/src/execution/local.rs
@@ -19,25 +19,23 @@
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use color_eyre::eyre::eyre;
 use datafusion::logical_expr::LogicalPlan;
-use datafusion_common::DataFusionError;
-use futures::{Future, TryFutureExt};
+use futures::TryFutureExt;
 use log::{debug, error, info};
 
 use crate::config::ExecutionConfig;
 use crate::extensions::{enabled_extensions, DftSessionStateBuilder};
 use color_eyre::eyre::{self, Result};
-use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream};
+use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::{execute_stream, ExecutionPlan};
 use datafusion::prelude::*;
 use datafusion::sql::parser::{DFParser, Statement};
 use tokio_stream::StreamExt;
 
-use super::executor::dedicated::{DedicatedExecutor, JobError};
+use super::executor::dedicated::DedicatedExecutor;
 use super::local_benchmarks::LocalBenchmarkStats;
 use super::stats::{ExecutionDurationStats, ExecutionStats};
 use super::AppType;

--- a/src/execution/local.rs
+++ b/src/execution/local.rs
@@ -83,13 +83,15 @@ impl ExecutionContext {
                 builder = builder.with_batch_size(config.tui_batch_size);
             }
             AppType::FlightSQLServer => {
+                builder = builder.with_batch_size(config.flightsql_server_batch_size);
                 if config.dedicated_executor_enabled {
-                    builder = builder.with_batch_size(config.flightsql_server_batch_size);
                     // Ideally we would only use `enable_time` but we are still doing
                     // some network requests as part of planning / execution which require network
                     // functionality.
+
                     let runtime_builder = tokio::runtime::Builder::new_multi_thread();
-                    let dedicated_executor = DedicatedExecutor::new("cpu_runtime", runtime_builder);
+                    let dedicated_executor =
+                        DedicatedExecutor::new("cpu_runtime", config.clone(), runtime_builder);
                     executor = Some(dedicated_executor)
                 }
             }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod dedicated_executor;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
 #[cfg(feature = "flightsql")]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod dedicated_executor;
+pub mod executor;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
 #[cfg(feature = "flightsql")]

--- a/src/flightsql_server/mod.rs
+++ b/src/flightsql_server/mod.rs
@@ -270,16 +270,6 @@ impl FlightSqlApp {
         }
     }
 
-    // pub async fn channel(&self) -> Channel {
-    //     let url = format!("http://{}", self.addr);
-    //     let uri: Uri = url.parse().expect("Valid URI");
-    //     Channel::builder(uri)
-    //         .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS))
-    //         .connect()
-    //         .await
-    //         .expect("error connecting to server")
-    // }
-
     /// Stops the server and waits for the server to shutdown
     pub async fn shutdown_and_wait(mut self) {
         if let Some(shutdown) = self.shutdown.take() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
             app.run_app().await;
         }
 
-        #[cfg(not(feature = "flightsql"))]
+        #[cfg(not(feature = "experimental-flightsql-server"))]
         {
             panic!("FlightSQL feature is not enabled");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,18 +39,12 @@ fn main() -> Result<()> {
 
     let state = state::initialize(cli.config_path());
 
-    let cpus = num_cpus::get();
-    let main_threads = if state.config.execution.dedicated_executor_enabled {
-        // Just for IO
-        (cpus as f64 * (1.0 - state.config.execution.dedicated_executor_threads_percent)) as usize
-    } else {
-        cpus
-    };
-
-    info!("Creating main Tokio Runtime with {main_threads} threads");
-
+    // With Runtimes configured correctly the main Tokio runtime should only be used for network
+    // IO, in which a single thread should be sufficient.
+    //
+    // Ref: https://github.com/datafusion-contrib/datafusion-dft/pull/247#discussion_r1848270250
     let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(main_threads)
+        .worker_threads(1)
         .enable_all()
         .build()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,12 @@ use dft::cli::CliApp;
 #[cfg(feature = "flightsql")]
 use dft::execution::flightsql::FlightSQLContext;
 use dft::execution::{local::ExecutionContext, AppExecution, AppType};
+#[cfg(feature = "experimental-flightsql-server")]
+use dft::flightsql_server::{FlightSqlApp, FlightSqlServiceImpl};
 use dft::telemetry;
 use dft::tui::state::AppState;
 use dft::tui::{state, App};
-#[cfg(feature = "experimental-flightsql-server")]
-use {
-    dft::flightsql_server::{FlightSqlApp, FlightSqlServiceImpl},
-    log::info,
-};
+use log::info;
 
 #[allow(unused_mut)]
 fn main() -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -85,6 +85,7 @@ pub enum AppEvent {
     FlightSQLConnected,
 }
 
+#[allow(dead_code)]
 pub struct App<'app> {
     state: state::AppState<'app>,
     execution: Arc<TuiExecution>,
@@ -93,7 +94,7 @@ pub struct App<'app> {
     cancellation_token: CancellationToken,
     task: JoinHandle<()>,
     ddl_task: Option<JoinHandle<()>>,
-    _args: DftArgs,
+    args: DftArgs,
 }
 
 impl<'app> App<'app> {
@@ -105,13 +106,13 @@ impl<'app> App<'app> {
 
         Self {
             state,
+            args,
             task,
             event_rx,
             event_tx,
             cancellation_token,
             execution: app_execution,
             ddl_task: None,
-            _args: args,
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -93,7 +93,7 @@ pub struct App<'app> {
     cancellation_token: CancellationToken,
     task: JoinHandle<()>,
     ddl_task: Option<JoinHandle<()>>,
-    args: DftArgs,
+    _args: DftArgs,
 }
 
 impl<'app> App<'app> {
@@ -105,13 +105,13 @@ impl<'app> App<'app> {
 
         Self {
             state,
-            args,
             task,
             event_rx,
             event_tx,
             cancellation_token,
             execution: app_execution,
             ddl_task: None,
+            _args: args,
         }
     }
 


### PR DESCRIPTION
Add's a dedicated executor for running CPU bound work on the FlightSQL server.

There is interest from the [DataFusion community](https://github.com/apache/datafusion/issues/13274#issuecomment-2468866602) for this, it was already on our [roadmap](https://github.com/datafusion-contrib/datafusion-dft/issues/197) and I think the DFT FlightSQL server is a great place to have a reference implementation.

Initial inspiration and context can be found [here](https://thenewstack.io/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/).

Most of the initial implementation was copied from [here](https://github.com/influxdata/influxdb3_core/blob/6fcbb004232738d55655f32f4ad2385523d10696/executor/src/lib.rs) with some tweaks for our current setup.  In particular we dont have metrics yet in the FlightSQL server implementation (but it is on the [roadmap](https://github.com/datafusion-contrib/datafusion-dft/issues/210)) - I expect to do a follow on where metrics are integrated.